### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ I recently demonstrated `GpxLocationManager` to the [Swift Language User Group](
 ## Use
 Here are the steps to use `GpxLocationManager` in your app.
 
-1. Obtain the framework via Cocoapods or by copying the files RaceRunner/GpxLocationManager.swift, LocationManager.swift, and GpxParser.swift to your project. If you go the Cocoapods route, you will need to `import GpxLocationManager` in any file using classes from that framework.
+1. Obtain the framework via CocoaPods or by copying the files RaceRunner/GpxLocationManager.swift, LocationManager.swift, and GpxParser.swift to your project. If you go the CocoaPods route, you will need to `import GpxLocationManager` in any file using classes from that framework.
 
 2. Where you were declaring and instantiating a `CLLocationManager`, instead declare and instantiate a `LocationManager`. Depending on how you instantiate `LocationManager`, there are three possibilities: (1) No arguments: `LocationManager` instantiates a `CLLocationManager` (2) Pass a `String` `gpxFile`: `LocationManager` instantiates a `GpxLocationManager` using the GPX filename you pass in, appending .gpx to the filename. (3) Pass a `[CLLocation]` `locations`: `LocationManager` instantiates a `GpxLocationManager` using the array of `CLLocation`s passed in. The wrapper `LocationManager` exists so that you can decide at run time whether you want a `GpxLocationManager` or `CLLocationManager` running under the hood. The demo uses this flexibility. If you don’t need this flexibility, you can instantiate `GpxLocationManager` directly, avoiding the `LocationManager` wrapper.
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
