### PR TITLE
Allow GpxLocationManager to be used more flexibly

### DIFF
--- a/Source/GpxLocationManager.swift
+++ b/Source/GpxLocationManager.swift
@@ -124,7 +124,7 @@ open class GpxLocationManager {
             let startDate = locations[0].timestamp
             let timeInterval = round(startDate.timeIntervalSince(locations[0].timestamp))
             for i in 0 ..< locations.count {
-                locations[i] = CLLocation(coordinate: locations[i].coordinate, altitude: locations[i].altitude, horizontalAccuracy: locations[i].horizontalAccuracy, verticalAccuracy: locations[i].verticalAccuracy, course: locations[i].course, speed: locations[i].speed, timestamp: locations[i].timestamp.addingTimeInterval(timeInterval))
+                locations[i] = CLLocation(coordinate: locations[i].coordinate, altitude: locations[i].altitude, horizontalAccuracy: locations[i].horizontalAccuracy, verticalAccuracy: locations[i].verticalAccuracy, course: locations[i].course, speed: 0.0, timestamp: locations[i].timestamp.addingTimeInterval(timeInterval))
             }
             let updateQueue = DispatchQueue(label: "update queue", attributes: [])
             updateQueue.async(execute: {

--- a/Source/GpxLocationManager.swift
+++ b/Source/GpxLocationManager.swift
@@ -62,7 +62,7 @@ open class GpxLocationManager {
     open var allowsBackgroundLocationUpdates = false
     
     open func startUpdatingLocation() {
-        self.isUpdatingLocations = false
+        self.isUpdatingLocations = true
         startLocationUpdateMachineIfNeeded()
     }
     
@@ -81,7 +81,7 @@ open class GpxLocationManager {
     }
     
     open func stopUpdatingLocation() {
-        self.isUpdatingLocations = true
+        self.isUpdatingLocations = false
     }
     
     open func startMonitoring(for region: CLRegion) {
@@ -134,7 +134,7 @@ open class GpxLocationManager {
                     var currentLocation = self.locations[currentIndex]
                     currentLocation = CLLocation(coordinate: currentLocation.coordinate, altitude: currentLocation.altitude, horizontalAccuracy: currentLocation.horizontalAccuracy, verticalAccuracy: currentLocation.verticalAccuracy, course: currentLocation.course, speed: currentLocation.speed, timestamp: currentLocation.timestamp.addingTimeInterval((routeDuration + TimeInterval(1.0)) * TimeInterval(loopsCompleted)))
                     if abs(currentLocation.timestamp.timeIntervalSince(startDate.addingTimeInterval(timeIntervalSinceStart))) < GpxLocationManager.dateFudge {
-                        if !self.isUpdatingLocations {
+                        if self.isUpdatingLocations {
                             self.callerQueue.async(execute: {
                                 self.delegate.locationManager?(self.dummyCLLocationManager, didUpdateLocations: [currentLocation])
                                 

--- a/Source/GpxLocationManager.swift
+++ b/Source/GpxLocationManager.swift
@@ -120,7 +120,7 @@ open class GpxLocationManager {
     fileprivate func startLocationUpdateMachineIfNeeded() {
         if !hasStarted {
             hasStarted = true
-            let startDate = Date()
+            let startDate = locations[0].timestamp
             let timeInterval = round(startDate.timeIntervalSince(locations[0].timestamp))
             for i in 0 ..< locations.count {
                 locations[i] = CLLocation(coordinate: locations[i].coordinate, altitude: locations[i].altitude, horizontalAccuracy: locations[i].horizontalAccuracy, verticalAccuracy: locations[i].verticalAccuracy, course: locations[i].course, speed: locations[i].speed, timestamp: locations[i].timestamp.addingTimeInterval(timeInterval))
@@ -143,7 +143,9 @@ open class GpxLocationManager {
                     }
                     var currentLocation = self.locations[currentIndex]
                     currentLocation = CLLocation(coordinate: currentLocation.coordinate, altitude: currentLocation.altitude, horizontalAccuracy: currentLocation.horizontalAccuracy, verticalAccuracy: currentLocation.verticalAccuracy, course: currentLocation.course, speed: currentLocation.speed, timestamp: currentLocation.timestamp.addingTimeInterval((routeDuration + TimeInterval(1.0)) * TimeInterval(loopsCompleted)))
-                    if abs(currentLocation.timestamp.timeIntervalSince(startDate.addingTimeInterval(timeIntervalSinceStart))) < GpxLocationManager.dateFudge {
+                    
+                    let timeIntervalBetweenExpectedUpdateAndNextLocation = currentLocation.timestamp.timeIntervalSince(startDate.addingTimeInterval(timeIntervalSinceStart))
+                    if abs(timeIntervalBetweenExpectedUpdateAndNextLocation) < GpxLocationManager.dateFudge {
                         if self.isUpdatingLocations {
                             self.callerQueue.async(execute: {
                                 self.delegate.locationManager?(self.dummyCLLocationManager, didUpdateLocations: [currentLocation])

--- a/Source/GpxLocationManager.swift
+++ b/Source/GpxLocationManager.swift
@@ -124,7 +124,7 @@ open class GpxLocationManager {
             let startDate = locations[0].timestamp
             let timeInterval = round(startDate.timeIntervalSince(locations[0].timestamp))
             for i in 0 ..< locations.count {
-                locations[i] = CLLocation(coordinate: locations[i].coordinate, altitude: locations[i].altitude, horizontalAccuracy: locations[i].horizontalAccuracy, verticalAccuracy: locations[i].verticalAccuracy, course: locations[i].course, speed: 0.0, timestamp: locations[i].timestamp.addingTimeInterval(timeInterval))
+                locations[i] = CLLocation(coordinate: locations[i].coordinate, altitude: locations[i].altitude, horizontalAccuracy: locations[i].horizontalAccuracy, verticalAccuracy: locations[i].verticalAccuracy, course: locations[i].course, speed: locations[i].speed, timestamp: locations[i].timestamp.addingTimeInterval(timeInterval))
             }
             let updateQueue = DispatchQueue(label: "update queue", attributes: [])
             updateQueue.async(execute: {
@@ -146,7 +146,7 @@ open class GpxLocationManager {
                     var currentLocation: CLLocation!
                     if (hasCompletedLocations) {
                         let lastLoc = self.locations.last!
-                        currentLocation = CLLocation(coordinate: lastLoc.coordinate, altitude: lastLoc.altitude, horizontalAccuracy: lastLoc.horizontalAccuracy, verticalAccuracy: lastLoc.verticalAccuracy, course: lastLoc.course, speed: lastLoc.speed, timestamp: startDate.addingTimeInterval(timeIntervalSinceStart))
+                        currentLocation = CLLocation(coordinate: lastLoc.coordinate, altitude: lastLoc.altitude, horizontalAccuracy: lastLoc.horizontalAccuracy, verticalAccuracy: lastLoc.verticalAccuracy, course: lastLoc.course, speed: 0.0, timestamp: startDate.addingTimeInterval(timeIntervalSinceStart))
                     } else {
                         currentLocation = self.locations[currentIndex]
                         currentLocation = CLLocation(coordinate: currentLocation.coordinate, altitude: currentLocation.altitude, horizontalAccuracy: currentLocation.horizontalAccuracy, verticalAccuracy: currentLocation.verticalAccuracy, course: currentLocation.course, speed: currentLocation.speed, timestamp: currentLocation.timestamp.addingTimeInterval((routeDuration + TimeInterval(1.0)) * TimeInterval(loopsCompleted)))

--- a/Source/GpxLocationManager.swift
+++ b/Source/GpxLocationManager.swift
@@ -186,7 +186,13 @@ open class GpxLocationManager {
                         
                         currentIndex += 1
                     }
-                    timeIntervalSinceStart += 1.0
+                    
+                    if (abs(timeIntervalBetweenExpectedUpdateAndNextLocation) >= GpxLocationManager.dateFudge && currentLocation.timestamp.timeIntervalSince(startDate.addingTimeInterval(timeIntervalSinceStart)) < 0) {
+                        // if our currentLocation is before startDate and too big to fudge, it's probably bad. skip over it without moving timeIntervalSinceStart.
+                        currentIndex += 1
+                    } else {
+                        timeIntervalSinceStart += 1.0
+                    }
                     if currentIndex == self.locations.count {
                         currentIndex = 0
                         loopsCompleted += 1


### PR DESCRIPTION
The major new use case here is being able to set locations after initializing GpxLocationManager. This is useful when you need to control when a location session begins. This is especially useful when testing UI: you can navigate somewhere in the UI and then begin a session, etc.

I also took the liberty of changing a behavior: instead of simply looping the locations array GpxLocationManager now repeats the last location by default (the old behavior is available via shouldRepeatLocations). My thinking here is that this is more realistic (ie it simulates that the user has stopped moving) and likely to fit into a testing scenario where multiple location sessions (in my case, trips) may be used. In my case, repeating the last location has the desired effect of ending a trip instead of continuing a discontinuous looping one for ever.