### PR TITLE
Basic Speed support

### DIFF
--- a/Demo/DemoView.swift
+++ b/Demo/DemoView.swift
@@ -40,14 +40,14 @@ class DemoView: UIView {
   private let actualSpeedLabelLabel: UILabel = {
     let actualSpeedLabelLabel = UILabel()
     actualSpeedLabelLabel.text = "Actual Speed: "
-    actualSpeedLabelLabel.textColor = UIColor.white
+    actualSpeedLabelLabel.textColor = .white
     return actualSpeedLabelLabel
   } ()
 
   internal let actualSpeedLabel: UILabel = {
     let actualSpeedLabel = UILabel()
     actualSpeedLabel.text = " "
-    actualSpeedLabel.textColor = UIColor.white
+    actualSpeedLabel.textColor = .white
     return actualSpeedLabel
   } ()
 

--- a/Demo/DemoView.swift
+++ b/Demo/DemoView.swift
@@ -25,7 +25,7 @@ class DemoView: UIView {
 
   private let speedLabelLabel: UILabel = {
     let speedLabelLabel = UILabel()
-    speedLabelLabel.text = "Speed: "
+    speedLabelLabel.text = "Speed Rate: "
     speedLabelLabel.textColor = UIColor.white
     return speedLabelLabel
   } ()
@@ -37,9 +37,23 @@ class DemoView: UIView {
     return speedLabel
   } ()
 
+  private let actualSpeedLabelLabel: UILabel = {
+    let actualSpeedLabelLabel = UILabel()
+    actualSpeedLabelLabel.text = "Actual Speed: "
+    actualSpeedLabelLabel.textColor = UIColor.white
+    return actualSpeedLabelLabel
+  } ()
+
+  internal let actualSpeedLabel: UILabel = {
+    let actualSpeedLabel = UILabel()
+    actualSpeedLabel.text = " "
+    actualSpeedLabel.textColor = UIColor.white
+    return actualSpeedLabel
+  } ()
+    
   override init(frame: CGRect) {
     super.init(frame: frame)
-    [mapView, gpxControl, speedLabelLabel, speedLabel, speedStepper].forEach { control in
+    [mapView, gpxControl, speedLabelLabel, speedLabel, speedStepper, actualSpeedLabel, actualSpeedLabelLabel].forEach { control in
       control.enableAutoLayout()
       addSubview(control)
     }
@@ -54,13 +68,20 @@ class DemoView: UIView {
     gpxControl.bottomAnchor.constraint(equalTo: speedStepper.topAnchor, constant: standard * -1.0).activate()
 
     speedStepper.leadingAnchor.constraint(equalTo: speedLabel.trailingAnchor, constant: standard).activate()
-    speedStepper.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor, constant: standard * -1.0).activate()
+    speedStepper.bottomAnchor.constraint(equalTo: actualSpeedLabel.topAnchor, constant: standard * -1.0).activate()
 
     speedLabel.centerXAnchor.constraint(equalTo: centerXAnchor).activate()
     speedLabel.centerYAnchor.constraint(equalTo: speedStepper.centerYAnchor).activate()
 
     speedLabelLabel.trailingAnchor.constraint(equalTo: speedLabel.leadingAnchor, constant: standard * -1.0).activate()
     speedLabelLabel.centerYAnchor.constraint(equalTo: speedStepper.centerYAnchor).activate()
+
+    actualSpeedLabel.centerXAnchor.constraint(equalTo: centerXAnchor).activate()
+    actualSpeedLabel.centerYAnchor.constraint(equalTo: actualSpeedLabelLabel.centerYAnchor).activate()
+
+    actualSpeedLabelLabel.trailingAnchor.constraint(equalTo: actualSpeedLabel.leadingAnchor, constant: standard * -1.0).activate()
+    actualSpeedLabelLabel.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor, constant: standard * -1.0).activate()
+
   }
 
   required init(coder aDecoder: NSCoder) {
@@ -72,12 +93,16 @@ class DemoView: UIView {
   }
 
   internal func enableSpeedControls() {
-    [speedLabelLabel, speedLabel, speedStepper].forEach { $0.alpha = 1.0 }
+    [speedLabelLabel, speedLabel, speedStepper, actualSpeedLabel, actualSpeedLabelLabel].forEach { $0.alpha = 1.0 }
     speedStepper.isEnabled = true
   }
 
   internal func disableSpeedControls() {
-    [speedLabelLabel, speedLabel, speedStepper].forEach { $0.alpha = disabledAlpha }
+    [speedLabelLabel, speedLabel, speedStepper, actualSpeedLabel, actualSpeedLabelLabel].forEach { $0.alpha = disabledAlpha }
     speedStepper.isEnabled = false
+  }
+
+  internal func updateActualSpeedLabel(speed: Double) {
+    actualSpeedLabel.text = "\(String(format: "%.2f", speed)) m/s"
   }
 }

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -109,5 +109,7 @@ class DemoViewController: UIViewController, CLLocationManagerDelegate {
     let pin = MKPointAnnotation()
     pin.coordinate = locations[0].coordinate
     demoView.mapView.addAnnotation(pin)
+
+    demoView.updateActualSpeedLabel(speed: locations[0].speed)
   }
 }

--- a/GpxLocationManager/GpxLocationManager.swift
+++ b/GpxLocationManager/GpxLocationManager.swift
@@ -175,7 +175,7 @@ open class GpxLocationManager {
             let speed: CLLocationSpeed
             if currentLocation.speed != -1 && currentLocation.speed != Double.infinity {
                 speed = currentLocation.speed
-            } else if self.locations.count >= currentIndex {
+            } else if self.locations.count > currentIndex + 1 {
                 speed = self.locations[currentIndex + 1].distance(from: currentLocation) / timeInterval
             } else {
                 speed = 0

--- a/GpxLocationManager/GpxLocationManager.swift
+++ b/GpxLocationManager/GpxLocationManager.swift
@@ -154,7 +154,17 @@ open class GpxLocationManager {
             currentLocation = CLLocation(coordinate: lastLoc.coordinate, altitude: lastLoc.altitude, horizontalAccuracy: lastLoc.horizontalAccuracy, verticalAccuracy: lastLoc.verticalAccuracy, course: lastLoc.course, speed: 0.0, timestamp: startDate.addingTimeInterval(timeIntervalSinceStart))
           } else {
             currentLocation = self.locations[currentIndex]
-            currentLocation = CLLocation(coordinate: currentLocation.coordinate, altitude: currentLocation.altitude, horizontalAccuracy: currentLocation.horizontalAccuracy, verticalAccuracy: currentLocation.verticalAccuracy, course: currentLocation.course, speed: currentLocation.speed, timestamp: currentLocation.timestamp.addingTimeInterval((routeDuration + TimeInterval(1.0)) * TimeInterval(loopsCompleted)))
+
+            let timeInterval = (routeDuration + TimeInterval(1.0)) * TimeInterval(loopsCompleted) + self.secondLength // true of the previous and the current span
+            let speed: CLLocationSpeed
+            if currentLocation.speed != -1 && currentLocation.speed != Double.infinity {
+                speed = currentLocation.speed
+            } else if self.locations.count >= currentIndex {
+                speed = self.locations[currentIndex + 1].distance(from: currentLocation) / timeInterval
+            } else {
+                speed = 0
+            }
+            currentLocation = CLLocation(coordinate: currentLocation.coordinate, altitude: currentLocation.altitude, horizontalAccuracy: currentLocation.horizontalAccuracy, verticalAccuracy: currentLocation.verticalAccuracy, course: currentLocation.course, speed: speed, timestamp: currentLocation.timestamp.addingTimeInterval(timeInterval))
           }
 
           let timeBetweenExpectedUpdateAndNextLocation = currentLocation.timestamp.timeIntervalSince(startDate.addingTimeInterval(timeIntervalSinceStart))


### PR DESCRIPTION
GPX 1.1 no longer provides a speed field, when it is not provided calculate `speed` manually, simple point to point calculation.

I haven't applied the linting and organization changes found in #22 because I assume we're going to merge that PR first. If not I can bring them to this change as well!